### PR TITLE
disable unnecessary/unused tracing-subscriber features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 libc = "0.2"
 tracing-core = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
 
 [dev-dependencies]
 gag = "1.0"
 once_cell = "1.13"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["json"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json"] }


### PR DESCRIPTION
They infect the dependency tree and cannot be disabled outside of this crate.