### PR TITLE
Never buffer in the write implementation

### DIFF
--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -289,7 +289,6 @@ impl<'a> MakeWriter<'a> for Syslog {
 
 /// [Writer](io::Write) to `syslog` produced by [`MakeWriter`].
 pub struct SyslogWriter {
-    flushed: bool,
     facility: Facility,
     level: Level,
 }
@@ -297,7 +296,6 @@ pub struct SyslogWriter {
 impl SyslogWriter {
     fn new(facility: Facility, level: Level) -> Self {
         SyslogWriter {
-            flushed: false,
             facility,
             level,
         }
@@ -336,7 +334,6 @@ impl io::Write for SyslogWriter {
             // Clear buffer
             buf.clear();
 
-            self.flushed = true;
             Ok(())
         })
     }
@@ -344,9 +341,7 @@ impl io::Write for SyslogWriter {
 
 impl Drop for SyslogWriter {
     fn drop(&mut self) {
-        if !self.flushed {
-            let _ = io::Write::flush(self);
-        }
+        drop(self.flush());
     }
 }
 


### PR DESCRIPTION
There are a few improvements I see with the current implementation:
 1. A write implementation should rarely buffer their own inputs and instead only make direct attempts at writing to the sink. Users that need better performance should use the `BufWriter` struct instead.
 2. Specifically for `syslog`, `syslog` makes no guarantees that a write was successful (no errno or return value), so flushing doesn't conceptually make too much sense to begin with.
 3. The current logic to check and flush on drop is faulty if there was call to `flush` and a write immediately after:
```rust
let writer = SyslogWriter::new(...);
writer.flush()?;
writer.write(b"hello world\n")?;
drop(writer);
```
This results in the message being lost.

This PR addresses all concerns by never using the buffer as buffered input to begin with (and only uses it as working space for non-nul-terminated data), and writes will always call `syslog`. Flushing now does nothing, as we never store any data to flush out nor can we determine if there is data to flush. Finally, if we're given garbage input (data with interior nulls) we now check for that and return an error on write.

This diff was tested with `cargo t`.